### PR TITLE
リンクすると.dataセクションが行方不明になる件の修正

### DIFF
--- a/Tips/LinkerSectionCheck/rpiMicon.lds
+++ b/Tips/LinkerSectionCheck/rpiMicon.lds
@@ -8,7 +8,7 @@ SECTIONS
 	. = ALIGN(4);
 
 	__rodata_start = .;
-	.rodata : { *(.data*) }
+	.rodata : { *(.rodata*) }
 	. = ALIGN(4);
 	__rodata_end = .;
 


### PR DESCRIPTION
こんにちは。『BareMetalで遊ぶRaspberry Pi』を楽しく読んでいるところです。

ところで、「3.7.3 セクション定義の確認」で.rodataセクションと.dataセクションがなぜか合併されているという件について、`rpiMicon.lds` の定義ミスではないかと思います。本Pull Requestの修正を行った上で `readelf` を実行すると次のような結果が得られます。

```
There are 10 section headers, starting at offset 0x840c:

Section Headers:
  [Nr] Name              Type            Addr     Off    Size   ES Flg Lk Inf Al
  [ 0]                   NULL            00000000 000000 000000 00      0   0  0
  [ 1] .text             PROGBITS        00008000 008000 0000bc 00  AX  0   0  4
  [ 2] .rodata           PROGBITS        000080bc 0080bc 00000c 00   A  0   0  4
  [ 3] .data             PROGBITS        000080c8 0080c8 000004 00  WA  0   0  4
  [ 4] .bss              NOBITS          000080cc 0080cc 000004 00  WA  0   0  4
  [ 5] .ARM.attributes   ARM_ATTRIBUTES  00000000 0080cc 000039 00      0   0  1
  [ 6] .comment          PROGBITS        00000000 008105 00002e 01  MS  0   0  1
  [ 7] .shstrtab         STRTAB          00000000 008133 00004d 00      0   0  1
  [ 8] .symtab           SYMTAB          00000000 008180 0001e0 10      9  18  4
  [ 9] .strtab           STRTAB          00000000 008360 0000aa 00      0   0  1
Key to Flags:
  W (write), A (alloc), X (execute), M (merge), S (strings)
  I (info), L (link order), G (group), T (TLS), E (exclude), x (unknown)
  O (extra OS processing required) o (OS specific), p (processor specific)
```

無事.rodataと.dataが別々のセクションになり、.rodataからはWフラグが消えます。